### PR TITLE
Clean dependencies and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,15 @@ class User extends Model implements OrderByDefaultOrderInterface
 {
     use OrderByDefaultOrderTrait;
 
-    public function getDefaultOrder()
-    {
-        /**
-         * Defaults to
-         * column: self::CREATED_AT
-         * asc: true
-         */
-        return [
-            'column' => 'last_login_at',
-            'asc' => 'desc',
-        ];
-    }
+    /**
+     * Defaults to :
+     * - column: `created_at`
+     * - asc: `true`
+     */
+    protected $defaultOrder = [
+        'column' => 'last_login_at',
+        'asc' => 'false',
+    ];
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -2,13 +2,11 @@
     "name": "kblais/laravel-helpers",
     "description": "A collection of helpers for your Laravel application.",
     "require": {
-        "illuminate/database": "~5.2",
-        "kblais/laravel-uuid": "^0.1.0",
-        "kblais/query-filter": "^1.1"
+        "illuminate/database": "^5.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0",
-        "orchestra/testbench": "^3.2"
+        "phpunit/phpunit": "^5.0",
+        "orchestra/testbench": "^3.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Eloquent/OrderByDefaultOrderTrait.php
+++ b/src/Eloquent/OrderByDefaultOrderTrait.php
@@ -3,6 +3,7 @@
 namespace Kblais\LaravelHelpers\Eloquent;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Kblais\LaravelHelpers\Eloquent\Scopes\OrderByScope;
 
 /**
@@ -27,8 +28,8 @@ trait OrderByDefaultOrderTrait
         $defaultOrder = with(new static)->getDefaultOrder();
 
         return new OrderByScope(
-            array_get($defaultOrder, 'column'),
-            array_get($defaultOrder, 'asc', true)
+            Arr::get($defaultOrder, 'column'),
+            Arr::get($defaultOrder, 'asc')
         );
     }
 
@@ -43,9 +44,13 @@ trait OrderByDefaultOrderTrait
 
     public function getDefaultOrder()
     {
+        if (property_exists($this, 'defaultOrder')) {
+            return $this->defaultOrder;
+        }
+
         return [
             'column' => self::CREATED_AT,
-            'asc' => null,
+            'asc' => true,
         ];
     }
 }

--- a/tests/OrderByDefaultTest.php
+++ b/tests/OrderByDefaultTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kblais\LaravelHelpers\Tests;
+
+use Kblais\LaravelHelpers\Eloquent\OrderByDefaultOrderInterface;
+use Kblais\LaravelHelpers\Eloquent\OrderByDefaultOrderTrait;
+use Kblais\LaravelHelpers\Tests\Models\User;
+
+class OrderByDefaultTest extends TestCase
+{
+	public function testModelHasDefaultDefaultOrder()
+	{
+		$user = new class extends User implements OrderByDefaultOrderInterface {
+			use OrderByDefaultOrderTrait;
+
+			protected $table = 'user';
+		};
+
+		$query = $user::query();
+
+		$this->assertEquals('select * from `user` order by `created_at` asc', $query->toSql());
+	}
+
+	public function testRemoveDefaultOrder()
+	{
+		$user = new class extends User implements OrderByDefaultOrderInterface {
+			use OrderByDefaultOrderTrait;
+
+			protected $table = 'user';
+		};
+
+		$query = $user::withoutDefaultOrder();
+
+		$this->assertEquals('select * from `user`', $query->toSql());
+	}
+
+	public function testModelHasCustomDefaultOrder()
+	{
+		$user = new class extends User implements OrderByDefaultOrderInterface {
+			use OrderByDefaultOrderTrait;
+
+			protected $table = 'user';
+
+			protected $defaultOrder = [
+	            'column' => 'id',
+	            'asc' => false,
+			];
+		};
+
+		$query = $user::query();
+
+		$this->assertEquals('select * from `user` order by `id` desc', $query->toSql());
+	}
+}

--- a/tests/SingularTableNameTest.php
+++ b/tests/SingularTableNameTest.php
@@ -3,11 +3,10 @@
 namespace Kblais\LaravelHelpers\Tests;
 
 use Illuminate\Http\Request;
-use Ramsey\Uuid\Uuid;
 use Kblais\LaravelHelpers\Tests\Models\Post;
 use Kblais\LaravelHelpers\Tests\Models\User;
 
-class UuidTest extends TestCase
+class SingularTableNameTest extends TestCase
 {
     public function testModelHasSingularTableName()
     {

--- a/tests/SingularTableNameTest.php
+++ b/tests/SingularTableNameTest.php
@@ -8,14 +8,14 @@ use Kblais\LaravelHelpers\Tests\Models\User;
 
 class SingularTableNameTest extends TestCase
 {
-    public function testModelHasSingularTableName()
+    public function testUserModelHasSingularTableName()
     {
         $user = new User;
 
         $this->assertEquals($user->getTable(), 'user');
     }
 
-    public function testModelHasCustomTableName()
+    public function testPostModelHasCustomTableName()
     {
         $post = new Post;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,30 +6,4 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->artisan('migrate', [
-            '--database' => 'testbench',
-            '--realpath' => realpath(__DIR__ . '/migrations'),
-        ]);
-
-        $this->beforeApplicationDestroyed(function () {
-            $this->artisan('migrate:rollback', [
-                '--database' => 'testbench',
-                '--realpath' => realpath(__DIR__ . '/migrations'),
-            ]);
-        });
-    }
-
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('database.default', 'testbench');
-        $app['config']->set('database.connections.testbench', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
-    }
 }


### PR DESCRIPTION
- Remove un-necessary dependency to kblais/laravel-uuid and kblais/query-filter
- Bump PHPUnit to 5.0 (maybe we could do something to update to a more recent one ?)
- Add a few tests for the OrderByDefaultTrait
- Remove the setup of database in the tests
- Refactor a bit the OrderByDefaultOrderTrait to avoir using now deprecated methods array_get
- Use a property to define the default order, instead of having to override a method
