### PR TITLE
Allow defining the relationship's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,21 @@ Route::resource('channel.message', 'MessageController')
     ->middleware('areRelated:channel,message');
 ```
 
+If you use custom route bindings, the middleware accepts a third attribute to define the relationship name. For example, if these bindings are defined:
+
+```php
+Route::bind('discussion', function ($value) {
+    return Channel::find($value);
+});
+```
+
+Your route definition will be:
+
+```php
+Route::resource('discussion.message', 'MessageController')
+    ->middleware('areRelated:discussion,message,channel');
+```
+
 ## Contributing
 
 ### Guidelines

--- a/src/Routing/Middleware/AreRelated.php
+++ b/src/Routing/Middleware/AreRelated.php
@@ -12,18 +12,24 @@ class AreRelated
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
-     * @param string                   $ownerRelation
-     * @param string                   $foreignRelation
+     * @param string                   $ownerParameter
+     * @param string                   $foreignParameter
+     * @param string                   $relationName
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $ownerRelation, $foreignRelation)
-    {
-        if ($foreignModel = $request->route($foreignRelation)) {
-            $ownerModel = $request->route($ownerRelation);
+    public function handle(
+        $request,
+        Closure $next,
+        $ownerParameter,
+        $foreignParameter,
+        $relationName = null
+    ) {
+        if ($foreignModel = $request->route($foreignParameter)) {
+            $ownerModel = $request->route($ownerParameter);
 
-            $foreignKey = $foreignModel->{$ownerRelation}()->getForeignKeyName();
-            $ownerKey = $foreignModel->{$ownerRelation}()->getOwnerKeyName();
+            $foreignKey = $foreignModel->{$relationName ?: $ownerParameter}()->getForeignKeyName();
+            $ownerKey = $foreignModel->{$relationName ?: $ownerParameter}()->getOwnerKeyName();
 
             if ($foreignModel->{$foreignKey} !== $ownerModel->{$ownerKey}) {
                 throw new ModelNotFoundException();


### PR DESCRIPTION
Add a thrid parameter to the AreRelated middleware to define the relation name.

Uses the owner parameter name by default.